### PR TITLE
fix(scan_against): replace inactivity socket timeout with an absolute deadline after connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### [1.0.4] - 2026-06-17
 
-- fix(scan_against): replace inactivity socket timeout with an absolute deadline after connect; the previous `socket.setTimeout` reset on every write during `message_stream.pipe()`, allowing large messages to exhaust Haraka's hook watchdog before the plugin's own timeout fired
+- fix(scan_against): replace inactivity timeout with absolute timeout #6
 - test: refactored against test-fixtures 1.7.0
 
 ### [1.0.3] - 2026-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [1.0.4] - 2026-06-17
+
+- fix(scan_against): replace inactivity socket timeout with an absolute deadline after connect; the previous `socket.setTimeout` reset on every write during `message_stream.pipe()`, allowing large messages to exhaust Haraka's hook watchdog before the plugin's own timeout fired
 - test: refactored against test-fixtures 1.7.0
 
 ### [1.0.3] - 2026-05-24

--- a/index.js
+++ b/index.js
@@ -241,21 +241,22 @@ function scan_against(plugin, connection, txn, host) {
     let connected = false
     let lastLine = ''
     let settled = false
+    let scanTimer = null
+
     const settle = (outcome) => {
       if (settled) return
       settled = true
+      clearTimeout(scanTimer)
       resolve(outcome)
     }
 
     socket.setTimeout((cfg.main.connect_timeout || 10) * 1000)
 
     socket.on('timeout', () => {
+      // Only fires during the connection phase; we disable the socket timeout
+      // after connect and switch to an absolute deadline (see below).
       socket.destroy()
-      settle(
-        connected
-          ? { kind: 'scan_timeout' }
-          : { kind: 'connect_failed', reason: 'timeout' },
-      )
+      settle({ kind: 'connect_failed', reason: 'timeout' })
     })
 
     socket.on('error', (err) => {
@@ -268,7 +269,14 @@ function scan_against(plugin, connection, txn, host) {
 
     socket.on('connect', () => {
       connected = true
-      socket.setTimeout((cfg.main.timeout || 30) * 1000)
+      // socket.setTimeout is an inactivity timer: every write during
+      // message_stream.pipe() resets it, so it cannot bound the total scan
+      // duration. Use an absolute deadline instead.
+      socket.setTimeout(0)
+      scanTimer = setTimeout(() => {
+        settle({ kind: 'scan_timeout' })
+        socket.destroy()
+      }, (cfg.main.timeout || 30) * 1000)
       const hp = socket.address()
       const addressInfo = hp === null ? '' : ` ${hp.address}:${hp.port}`
       connection.logdebug(plugin, `connected to host${addressInfo}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-clamd",
-  "version": "1.0.4",
+  "version": "1.0.3",
   "description": "Haraka plugin that scans emails with clamd",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-clamd",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Haraka plugin that scans emails with clamd",
   "main": "index.js",
   "files": [

--- a/test/index.js
+++ b/test/index.js
@@ -411,5 +411,34 @@ describe('plugins/clamd', () => {
       })
       assert.equal(args[0], DENYSOFT)
     })
+
+    it('DENYSOFTs when clamd connects but never replies (scan timeout)', async () => {
+      await primeTxn()
+      // Server that accepts the connection and drains data but never sends a response,
+      // simulating a clamd that stalls mid-scan (e.g. during a database reload).
+      let serverConn = null
+      server = net.createServer({ allowHalfOpen: true }, (s) => {
+        serverConn = s
+        s.on('data', () => {})
+      })
+      const addr = await new Promise((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+          const { port } = server.address()
+          resolve(`127.0.0.1:${port}`)
+        })
+      })
+      this.plugin.cfg.main.clamd_socket = addr
+      this.plugin.cfg.main.timeout = 0.05 // 50 ms so the test runs fast
+      this.plugin.cfg.reject.error = true
+      const [code] = await runHook((next) =>
+        this.plugin.hook_data_post(next, this.connection),
+      )
+      // Destroy the server-side socket so afterEach's server.close() can complete;
+      // with allowHalfOpen:true the server never auto-closes after receiving client FIN.
+      serverConn?.destroy()
+      assert.equal(code, DENYSOFT)
+      const r = this.connection.transaction.results.get('clamd')
+      assert.ok(r.err.join().includes('timed out'))
+    })
   })
 })


### PR DESCRIPTION
Fix attempt for:

```
[CRIT] [1AC27CB6-4210-4CDC-9CF0-3D161269FA72.1] [core] Plugin clamd timed out on hook data_post - make sure it calls the callback
```

Provided by Claude.

replace inactivity socket timeout with an absolute deadline after connect; the previous `socket.setTimeout` reset on every write during `message_stream.pipe()`, allowing large messages to exhaust Haraka's hook watchdog before the plugin's own timeout fired

Checklist:

- [ ] docs updated
- [x] tests updated
- [x] Changes.md updated
