### PR TITLE
fix(classify_outcome): guard against null transaction when client disconnects during scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [1.0.5] - 2026-06-18
+
+- fix(classify_outcome): guard against null transaction when client disconnects during scan
+
 ### [1.0.4] - 2026-06-17
 
 - fix(scan_against): replace inactivity timeout with absolute timeout #6
@@ -45,3 +49,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 [1.0.2]: https://github.com/haraka/haraka-plugin-clamd/releases/tag/v1.0.2
 [1.0.3]: https://github.com/haraka/haraka-plugin-clamd/releases/tag/v1.0.3
 [1.0.4]: https://github.com/haraka/haraka-plugin-clamd/releases/tag/v1.0.4
+[1.0.5]: https://github.com/haraka/haraka-plugin-clamd/releases/tag/v1.0.5

--- a/index.js
+++ b/index.js
@@ -186,6 +186,8 @@ function classify_outcome(plugin, connection, host, isLast, outcome) {
   const { cfg } = plugin
   const txn = connection.transaction
 
+  if (!txn) return ACCEPT // client disconnected while clamd was scanning
+
   if (outcome.kind === 'connect_failed') {
     connection.logerror(
       plugin,
@@ -241,6 +243,7 @@ function classify_outcome(plugin, connection, host, isLast, outcome) {
 
 function classify_virus(plugin, connection, virus) {
   const txn = connection.transaction
+  if (!txn) return ACCEPT // client disconnected while clamd was scanning
   txn.results.add(plugin, { fail: virus || 'virus', emit: true })
   const decision = decide_virus_action(plugin, virus)
   if (decision.matched_exclusion) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-clamd",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Haraka plugin that scans emails with clamd",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Guard against null transaction when client disconnects during scan.

Should fix:

```
[CRIT] [-] [core] TypeError: Cannot read properties of null (reading 'results')
[CRIT] [-] [core]     at classify_outcome (/path/to/Haraka/node_modules/haraka-plugin-clamd/index.js:214:9)
[CRIT] [-] [core]     at exports.hook_data_post (/path/to/Haraka/node_modules/haraka-plugin-clamd/index.js:159:22)
[CRIT] [-] [core]     at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

Claude analysis:

```
The bug is clear. In classify_outcome, txn = connection.transaction is assigned at line 187. The scan is async (clamd can take a while), so the client can disconnect mid-scan. Haraka sets connection.transaction to null on teardown. When the scan resolves and classify_outcome runs, txn is null and txn.results.add(...) crashes.

The fix is a null guard at the top of classify_outcome. [...]
Same pattern exists in classify_virus at line 243. [...]

Root cause: the scan is async (clamd), the client can disconnect mid-flight, and Haraka nulls connection.transaction on teardown. Both classify_outcome and classify_virus dereferenced txn without checking for null first. The fix adds an early-return ACCEPT (no-op) in both functions when the transaction is already gone.
```

Checklist:

- [ ] docs updated
- [ ] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped
